### PR TITLE
BUG FIX: parent.children

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -52,7 +52,6 @@ function getArticle(candidates, $) {
     var siblings = elem.find("*").length;
 
     elem.data('readabilityScore', Math.max(2, siblings) * score * (1 - linkDensity));
-    //console.log([elem.get(0).name, elem.attr('class'), elem.data('readabilityScore')]);
     if (!topCandidate || elem.data('readabilityScore') > topCandidate.data('readabilityScore')) {
       topCandidate = elem;
     }


### PR DESCRIPTION
sorry i made a mistake on last commit.

_topCandidate.parent().get(0).children_ would return children, but not _topCandidate.parent().get(0).children()_
