### PR TITLE
considerDIVs

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function Article(dom, options, uri) {
   } else {
     this.base = false;
   }
+  this.options = options;
   this.__defineGetter__('content', function() {
     return this.getContent(true);
   });
@@ -29,7 +30,7 @@ Article.prototype.getContent = function() {
   if (typeof this.cache['article-content'] !== 'undefined') {
     return this.cache['article-content'];
   }
-  return this.cache['article-content'] = utils.extract(this.$, this.base).html();
+  return this.cache['article-content'] = utils.extract(this.$, this.base, this.options).html();
 }
 
 // Better Article Title Extraction. 
@@ -78,7 +79,7 @@ Article.prototype.getHTML = function() {
 var read = module.exports = function(html, options, callback) {
   if (typeof options === 'function') {
     callback = options;
-    options = {};
+    options = {considerDIVs: true};
   }
 
   if (!html.match(/^\s*</)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -43,15 +43,19 @@ var trashNodes = 'meta,iframe,noscript,style,aside,object,form,script';
  * Select the TopCandidate from all possible candidates
  **/
 
-function getArticle(candidates, $) {
+function getArticle(candidates, $, options) {
   var topCandidate = null;
 
   candidates.forEach(function(elem) {
     var linkDensity = getLinkDensity(elem, $);
     var score = elem.data('readabilityScore');
-    var siblings = elem.find("*").length;
+    // actually say, we can't score node by children length
+    // e.g.: sometimes, the comments of an article have lots of children,
+    // such as: like, dislike, follow, print, star+/-...
+    // but most of them worthless.
+    // var siblings = elem.children().length;
 
-    elem.data('readabilityScore', Math.max(2, siblings) * score * (1 - linkDensity));
+    elem.data('readabilityScore', /*Math.max(2, siblings) * */ score * (1 - linkDensity));
     if (!topCandidate || elem.data('readabilityScore') > topCandidate.data('readabilityScore')) {
       topCandidate = elem;
     }
@@ -82,14 +86,12 @@ function getArticle(candidates, $) {
 function filterCandidates(topCandidate, siblings, $) {
   var articleContent = $("<div id='readabilityArticle'></div>");
   var siblingScoreThreshold = Math.max(10, topCandidate.data('readabilityScore') * 0.2);
-
   siblings.each(function(index, elem) {
     var sibling = $(this);
     var append = false;
     var type = sibling.get(0).name;
     var score = sibling.data('readabilityScore');
     var children = siblings.contents().length;
-
     if (sibling === topCandidate || score > siblingScoreThreshold) {
       append = true;
     }
@@ -121,7 +123,7 @@ function filterCandidates(topCandidate, siblings, $) {
  * Traverse all Nodes and remove unlikely Candidates.
  **/
 
-function getCandidates($, base, considerDIVs) {
+function getCandidates($, base, options) {
 
   $(trashNodes).remove();
   // Candidates Array
@@ -150,44 +152,27 @@ function getCandidates($, base, considerDIVs) {
     // Remove Style 
     node.removeAttr('style');
 
-    if (nodeType == "div" && considerDIVs && classAndID.search(regexps.okMaybeItsACandidateRe) !== -1) {
-      var score = initializeNode(node.parent());
-      scoreCandidate(node.parent(), score, candidates);
-      return;
+    // turn all divs that don't have children block level elements into p's
+    if (nodeType === "div" && options.considerDIVs) {
+      if (node.html().search(regexps.divToPElementsRe) === -1) {
+        node.replaceWith('<p class="node-read-div2p">' + node.html() + '</p>');
+      } else {
+        node.contents().each(function(index, element){
+          var child = $(this), childEntity;
+          if(!child || !(childEntity = child.get(0))){
+            return;
+          }
+          if(childEntity.type == 'text' && childEntity.data && childEntity.data.replace(regexps.trimRe, '').length > 0){
+            child.replaceWith('<p class="node-read-div2p">' + childEntity.data + '</p>');
+          }
+        });
+      }
     }
 
+    // score paragraphs.
     if (nodeType == "p") {
-      var txt = node.text();
-
-      // Ignore too small nodes
-      if (txt.length < 25) return;
-
-      var contentScore = 0;
-
-      // Add a point for the paragraph itself as a base. */
-      ++contentScore;
-
-      // Add points for any commas within this paragraph */
-      // support Chinese commas.
-      var commas = txt.match(/[,，.。;；?？、]/g);
-      if (commas && commas.length) {
-        contentScore += commas.length;
-      }
-
-      // For every 100 characters in this paragraph, add another point. Up to 3 points. */
-      contentScore += Math.min(Math.floor(txt.length / 100), 3);
-
-      // Initialize Parent and Grandparent
-      // First initialize the parent node with contentScore / 1, then grandParentNode with contentScore / 2
-      var parent = node.parent();
-
-      if (parent && parent.length > 0) {
-        scoreCandidate(parent, contentScore, candidates);
-        var grandParent = parent.parent();
-        if (grandParent && grandParent.length > 0) {
-          scoreCandidate(parent, contentScore / 2, candidates);
-        }
-      }
+      calculateNodeScore(node, candidates);
+      return;
     }
 
     // Resolve URLs
@@ -210,9 +195,19 @@ function getCandidates($, base, considerDIVs) {
     }
 
   });
+  // calculate scores of `P`s that were turned from DIV by us.
+  $('p.node-read-div2p', 'body').each(function(){
+    calculateNodeScore($(this), candidates);
+  });
   return candidates;
 }
 
+/**
+ * save score datas to nodes need score.
+ * @param node
+ * @param contentScore
+ * @param candidates
+ */
 function scoreCandidate(node, contentScore, candidates) {
   var score;
   if (typeof node.data('readabilityScore') == "undefined") {
@@ -223,6 +218,45 @@ function scoreCandidate(node, contentScore, candidates) {
   }
   node.data('readabilityScore', score + contentScore)
 }
+
+/**
+ * calculate score of specified node.
+ * @param node
+ * @param candidates
+ */
+function calculateNodeScore(node, candidates){
+  var txt = node.text();
+  // Ignore too small nodes
+  if (txt.length < 25) return;
+
+  var contentScore = 0;
+
+  // Add a point for the paragraph itself as a base.
+  ++contentScore;
+
+  // Add points for any commas within this paragraph
+  // support Chinese commas.
+  var commas = txt.match(/[,，.。;；?？、]/g);
+  if (commas && commas.length) {
+    contentScore += commas.length;
+  }
+
+  // For every 100 characters in this paragraph, add another point. Up to 3 points.
+  contentScore += Math.min(Math.floor(txt.length / 100), 3);
+
+  // Initialize Parent and Grandparent
+  // First initialize the parent node with contentScore / 1, then grandParentNode with contentScore / 2
+  var parent = node.parent();
+
+  if (parent && parent.length > 0) {
+    scoreCandidate(parent, contentScore, candidates);
+    var grandParent = parent.parent();
+    if (grandParent && grandParent.length > 0) {
+      scoreCandidate(grandParent, contentScore / 2, candidates);
+    }
+  }
+}
+
 /**
  * Check the type of node, and get its Weight
  **/
@@ -275,10 +309,9 @@ function getLinkDensity(node, $) {
  * If the first run does not succeed, try the body element;
  **/
 
-module.exports.extract = function($, base) {
-  var candidates = getCandidates($, base);
-  if (candidates.length < 2) candidates = getCandidates($, base, true);
-  article = getArticle(candidates, $);
+module.exports.extract = function($, base, options) {
+  var candidates = getCandidates($, base, options);
+  article = getArticle(candidates, $, options);
   if (article.length < 1) {
     article = getArticle([$('body')], $)
   }


### PR DESCRIPTION
Hi, Vadim:

I've saw your codes about **considerDIVs**, and actually, i am working on this issue days, and find that not all the pages are using 'P' tag to wrap their article content, so **considerDIVs** is really necessary.

but my thought was little difference from your:
- node-read must consider all candidates that match _divToPElementsRe_ if client user needed, so, i add an optional setting named _considerDIVs_, and it's value default as true, usage:
  
  `read([URL], { considerDIVs: false}, function(err, article){...})`
- the implementation way reference to Arc90's: turn all divs that don't have children block level elements into p's, including the matched Ps and TEXT node.
- **TEST**
  
  i've test it on thousands pages from _msn.com.cn_, _21cn.com_, _sina.com_, _163.com_, _cnbeta.com_...

if you think its feasible, or have any idea, or it can not work on some specified pages, just tell me, let's work on this together.

thx!!!
