### PR TITLE
Critical Bug: compare two CHEERIO Object equal or not.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,7 +92,7 @@ function filterCandidates(topCandidate, siblings, $) {
     var type = sibling.get(0).name;
     var score = sibling.data('readabilityScore');
     var children = siblings.contents().length;
-    if (sibling === topCandidate || score > siblingScoreThreshold) {
+    if (sibling.is(topCandidate) || score > siblingScoreThreshold) {
       append = true;
     }
     if (children > 0) {


### PR DESCRIPTION
Hey, Vadim:
the method that comparing two cheerio object **_obj1 === obj2**_ is totally wrong, you can take a test like below:

``` javascript
var html = '<div><p class="text">SAME</p><p>DIFF</p></div>';
var $ = cheerio.load(html);
var p = $('p.text');
p.parent().children().each(function(index, element){
  var sibling = $(this);
  console.log(sibling.text(), sibling.is(p), '.is()');
  console.log(sibling.text(), sibling.get(0) === p.get(0), 'equal with .get(0)');
  console.log(sibling.text(), sibling === p, 'equal with cheerio object');
});
```

and the console logs will be:

``` javascript
SAME true .is()
SAME true equal with .get(0)
SAME false equal with cheerio object
DIFF false .is()
DIFF false equal with .get(0)
DIFF false equal with cheerio object
```

it means that you can not compare them with **_obj1 === obj2**_, but **_obj1.get(0) === obj2.get(0)**_ and **_obj1.is(obj2)**_ are both fine.

as you known, in javascript, **===** means two objects are strictly equal if they refer to the same object. unfortunately, in Cheerio, two object does not have the same reference, even they have same innerHTML(WHY???)
