### PR TITLE
BugFix in url resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ function Article(dom, options, uri) {
   this.cache = {};
 
   if (uri && typeof uri != "undefined") {
-    this.base = uri.protocol + "//" + uri.hostname;
+    this.base = uri.protocol + "//" + uri.hostname + uri.pathname;
     if (uri.port && uri.port != 80) this.base += ":" + uri.port;
   } else {
     this.base = false;


### PR DESCRIPTION
Fix a problem in the uri:
if the base url is like http://site.com/folder/public/…/
the image url is relative to http://site.com/ and result in a 404 not
found.
