### PR TITLE
only use the first title for text

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ Article.prototype.getTitle = function() {
     return this.cache['article-title'] = preferredTitle.first().text().trim();
   }
 
-  var title = this.$('title').text();
+  var title = this.$('title').first().text();
   var betterTitle;
   var commonSeparatingCharacters = [' | ', ' _ ', ' - ', '«', '»', '—'];
 


### PR DESCRIPTION
in case of multiple titles, the text is joined into a single title, which gives odd results. 

Eg: 
https://www.economist.com/news/europe/21727046-frances-young-president-slides-polls-part-because-he-doing-right-things-emmanuel?fsrc=scn/tw/te/bl/ed/
http://news.nationalgeographic.com/2017/06/faceless-fish-deep-sea-voyage-australia/

this also fixes https://github.com/bndr/node-read/issues/28